### PR TITLE
Fix: Admin approval for transfers can be bypassed

### DIFF
--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -629,6 +629,9 @@ function CollectionFactory(params: {
         this.packedData.getAndRequireEquals()
       );
       collectionData.isPaused.assertFalse(CollectionErrors.collectionPaused);
+      collectionData.requireTransferApproval.assertFalse(
+        CollectionErrors.transferApprovalRequired
+      );
 
       const transferEventDraft = new TransferExtendedParams({
         from,


### PR DESCRIPTION
The function transferByProof() can be used to transfer ownership using a proof, in case the NFT owner or the approved address is a contract.

This method is missing an important validation. As highlighted in the snippet below, it does not verify that CollectionData.requireTransferApproval is false. Therefore, the admin approval requirement can be bypassed.

```typescript
@method async transferByProof(params: TransferParams): Promise<void> {
  const { address, from, to, price, context } = params;
  const collectionData = CollectionData.unpack(
    this.packedData.getAndRequireEquals()
  );
  collectionData.isPaused.assertFalse(CollectionErrors.collectionPaused);
  // Veridise - Missing check which validates that admin approval is not required.
	//[...elided]
	
  const canTransfer = await approvalContract.canTransfer(transferEvent);
  canTransfer.assertTrue();
}
```