### PR TITLE
fix: Approving a delegate address does not verify permissions

### DIFF
--- a/packages/nft/src/contracts/nft.ts
+++ b/packages/nft/src/contracts/nft.ts
@@ -30,6 +30,7 @@ const NftErrors = {
   cannotChangeMetadataVerificationKeyHash:
     "Cannot change metadata verification key hash",
   cannotChangeOwner: "Cannot change owner",
+  cannotChangeApproval: "Cannot change approval",
   cannotChangeStorage: "Cannot change storage",
   cannotChangePauseState: "Cannot change pause state",
   noPermissionToPause: "No permission to pause",
@@ -282,6 +283,7 @@ class NFT extends SmartContract {
   async approveAddress(approved: PublicKey): Promise<PublicKey> {
     const data = NFTData.unpack(this.packedData.getAndRequireEquals());
     data.isPaused.assertFalse(NftErrors.nftIsPaused);
+    data.canApprove.assertTrue(NftErrors.cannotChangeApproval);
     data.approved = approved;
     this.packedData.set(data.pack());
     this.emitEvent("approve", approved);


### PR DESCRIPTION
## Approving a delegate address does not verify if changing approval is allowed

The function approveAddess() can be used to set or change the NFT’s approved address for delegated actions. See snippet below for details.

```typescript
  @method.returns(PublicKey)
  async approveAddress(approved: PublicKey): Promise<PublicKey> {
    const data = NFTData.unpack(this.packedData.getAndRequireEquals());
    data.isPaused.assertFalse(NftErrors.nftIsPaused);
    data.approved = approved;
    this.packedData.set(data.pack());
    this.emitEvent("approve", approved);
    return data.owner;
  }
  
  class NFTData extends Struct({
	//[elided]..
	/** Specifies if the NFT's approved address can be changed (readonly). */
  canApprove: Bool, // readonly
	//[elided]..
})
```
However, this function is missing an important check. The NFTData contains a field canApprove   which is used to specify if the NFT's approved address can be changed. This field is not validated within this function. So, the approved address can be set even when canApprove is false.