### PR TITLE
fix: oracle missing in equality check

### DIFF
--- a/packages/nft/src/interfaces/types.ts
+++ b/packages/nft/src/interfaces/types.ts
@@ -223,6 +223,7 @@ class NFTState extends Struct({
     a.metadataVerificationKeyHash.assertEquals(b.metadataVerificationKeyHash);
     a.creator.assertEquals(b.creator);
     NFTTransactionContext.assertEqual(a.context, b.context);
+    a.oracleAddress.assertEquals(b.oracleAddress);
   }
 
   /**


### PR DESCRIPTION
`NFTState.assertEqual()` checks that two `NFTState` instances are exactly equal. It does this by asserting equality of each field of the two structs. However, the `oracleAddress` field is left out of this function. Consequently, if two `NFTState`s `a` and `b` are exactly equal except `a.oracleAddress != b.oracleAddress`, `NFTState.assertEqual(a,b)` will not cause an assertion failure.

Fortunately, this function is only called once in the in-scope portion of the codebase: inside `NFT.update()`. Immediately after it is invoked, the `oracleAddress` is checked to equal the desired value.

```typescript
NFTState.assertEqual(
    input,
    new NFTState({
      // [VERIDISE] elided...
      oracleAddress: input.oracleAddress,
    })
  );

// assert that the read-only fields are not changed
input.creator.assertEquals(output.creator);
NFTTransactionContext.assertEqual(input.context, output.context);
input.oracleAddress.assertEquals(output.oracleAddress);
   
```