### PR TITLE
fix: Permanently paused NFTs can be minted

### DIFF
--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -358,6 +358,10 @@ function CollectionFactory(params: {
 
       this.network.globalSlotSinceGenesis.requireBetween(UInt32.zero, expiry);
       data.version.assertEquals(UInt32.zero);
+      data.isPaused
+        .equals(Bool(false))
+        .or(data.canPause.equals(Bool(true)))
+        .assertTrue(CollectionErrors.cannotMint);
       const packedData = data.pack();
       const tokenId = this.deriveTokenId();
 


### PR DESCRIPTION
`Collection._mint()` takes in an authorized `MintParams` request and mints a new `NFT`. However, it does not perform any checks that the minted `NFT` is consistent with its own configuration.

While most state is trivially consistent with the `NFT`'s configuration, there is one notable exception. Some `NFT`s are unpausable, but nonetheless have an `isPaused` flag. 

Snippet fron `NFTData` in `packages/nft/src/interfaces/types.ts`:
```typescript
/** Specifies if the NFT contract can be paused, preventing certain operations (readonly). */
canPause: Bool, // readonly
/** Indicates whether the NFT contract is currently paused. */
isPaused: Bool,
```
As seen below, if an unpausable NFT is minted, it cannot be resumed.
```typescript
  @method.returns(PublicKey)
  async resume(): Promise<PublicKey> {
    const data = NFTData.unpack(this.packedData.getAndRequireEquals());
    data.canPause.assertTrue(NftErrors.noPermissionToPause);
```