### PR TITLE
fix: Incorrect URI/Symbol access control

### DIFF
--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -159,8 +159,8 @@ function CollectionFactory(params: {
         setPermissions: Permissions.impossible(),
         access: Permissions.proof(),
         send: Permissions.proof(),
-        setZkappUri: Permissions.none(),
-        setTokenSymbol: Permissions.none(),
+        setZkappUri: Permissions.proof(),
+        setTokenSymbol: Permissions.proof(),
       });
     }
 


### PR DESCRIPTION
`Collection.deploy()` defines the `AccountUpdate` which deployers are expected to use when deploying a `Collection`. The account permissions configured by `deploy()` are shown below.

The `setZkappUri` permission, which allows users to set the `Collection`'s `zkappUri`, and the `setTokenSymbol` permission, which allows users to change the `Collection`'s token symbol, are both set to `Permissions.none()`. This means any account update may change the `zkappUri` or the token symbol.

Fortunately, the `access` permission is set to `proof`, preventing any non-proof authorized `AccountUpdate`s to the `Collection` account.

 Snippet from `Collection.deploy()`

```typescript
 this.account.permissions.set({
  ...Permissions.default(),
  setVerificationKey:
    Permissions.VerificationKey.proofDuringCurrentVersion(),
  setPermissions: Permissions.impossible(),
  access: Permissions.proof(),
  send: Permissions.proof(),
  setZkappUri: Permissions.none(),
  setTokenSymbol: Permissions.none(),
});
```

#### Recommendation

Set the `setZkappUri` and `setTokenSymbol` permissions to be either impossible or controlled via signature/proof.