### PR TITLE
fix: MintParams fee/tokenId unused

### DIFF
--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -354,12 +354,15 @@ function CollectionFactory(params: {
         storage,
         metadataVerificationKeyHash,
         expiry,
+        fee,
+        tokenId,
       } = params;
 
       this.network.globalSlotSinceGenesis.requireBetween(UInt32.zero, expiry);
       data.version.assertEquals(UInt32.zero);
       const packedData = data.pack();
-      const tokenId = this.deriveTokenId();
+      const collectionTokenId = this.deriveTokenId();
+      collectionTokenId.assertEquals(tokenId);
 
       const update = AccountUpdate.createSigned(address, tokenId);
       update.body.useFullCommitment = Bool(true); // Prevent memo and fee change
@@ -459,6 +462,8 @@ function CollectionFactory(params: {
       const event = new MintEvent({
         initialState,
         address,
+        tokenId,
+        fee,
       });
       this.emitEvent("mint", event);
       return event;

--- a/packages/nft/src/interfaces/events.ts
+++ b/packages/nft/src/interfaces/events.ts
@@ -1,4 +1,4 @@
-import { PublicKey, Struct, UInt32, Field, Bool } from "o1js";
+import { PublicKey, Struct, UInt32, Field, Bool, UInt64 } from "o1js";
 import { Storage } from "@silvana-one/storage";
 import { NFTStateStruct, UInt64Option } from "./types.js";
 
@@ -21,6 +21,10 @@ class MintEvent extends Struct({
   initialState: NFTStateStruct,
   /** The public key address of the minted NFT. */
   address: PublicKey,
+  /** The token ID of the minted NFT. */
+  tokenId: Field,
+  /** The fee paid for the minting. */
+  fee: UInt64,
 }) {}
 
 /**

--- a/packages/nft/src/interfaces/events.ts
+++ b/packages/nft/src/interfaces/events.ts
@@ -23,7 +23,11 @@ class MintEvent extends Struct({
   address: PublicKey,
   /** The token ID of the minted NFT. */
   tokenId: Field,
-  /** The fee paid for the minting. */
+  /** The fee paid for the minting.
+   *  This fee is controlled by the admin contract
+   *  and is not checked by the Collection contract
+   *  Please check the admin contract code before using this fee
+   */
   fee: UInt64,
 }) {}
 


### PR DESCRIPTION
`mint()` and `mintByCreator()` can be used to mint new NFTs within a `Collection`. Additionally, `initialize()` mints a “master NFT” when initializing the `Collection`. All rely on `MintParams` specified by either the `creator` or the `admin`.

In all three functions, the `MintParams.tokenId` and `MintParams.fee` values are unchecked.

Definition of `MintParams`:

```typescript
/**
 * Represents the parameters required for minting a new NFT.
 */
class MintParams extends Struct({
  // [VERIDISE] elided other fields...
  
  /** The token ID of the NFT. */
  tokenId: Field,
  // [VERIDISE] elided other fields...
  
  /** The fee associated with minting the NFT. */
  fee: UInt64,
  // [VERIDISE] elided other fields...
}) {
```

### Recommendation

Assert that the returned `tokenId` matches the `Collection`'s derived token ID.

Remove `fee` from the `MintParams` struct.

### Changes
- Added check for tokenId
- Added fee to MintEvent as this is required for indexing on minascan  explore that keeps track of the NFT prices