### PR TITLE
fix: Oracle approval for updates can be bypassed

### DIFF
--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -480,6 +480,12 @@ function CollectionFactory(params: {
       proof: NFTUpdateProof,
       vk: VerificationKey
     ): Promise<void> {
+      // The oracle address is optional and can be empty, NFT ZkProgram can verify the address
+      // as it can be different for different NFTs. It should be empty for the update() call
+      const oracleAddress = proof.publicInput.oracleAddress;
+      oracleAddress
+        .equals(PublicKey.empty())
+        .assertTrue(CollectionErrors.invalidOracleAddress);
       await this._update(proof, vk);
     }
 
@@ -494,7 +500,7 @@ function CollectionFactory(params: {
       vk: VerificationKey
     ): Promise<void> {
       // The oracle address is optional and can be empty, NFT ZkProgram can verify the address
-      // as it can be different for different NFTs
+      // as it can be different for different NFTs. It should be non-empty for the updateWithOracle() call
       const oracleAddress = proof.publicInput.oracleAddress;
       oracleAddress
         .equals(PublicKey.empty())


### PR DESCRIPTION
In the Collection contract, the methods updateWithOracle() can be called to update a particular NFT with admin and oracle approval. The proof provided as input to the method contains an optional oracleAddress which can be used to link the NFT update with the network and accounts state.

Similarly, the method update() takes in a proof as input and updates the NFT without approval from the oracle. See snippet below for details.

```typescript
@method async update(
  proof: NFTUpdateProof,
  vk: VerificationKey
): Promise<void> {
  await this._update(proof, vk);
}
```

Here, the update() function does not validate that the proofs publicly input oracleAddress is empty. Therefore, it can be called with a proof containing an oracleAddress, to bypass the oracle approval and validations.

## Recommendation

In the `update()` method, check that the proof's publicly input oracle address is empty.