### PR TITLE
fix: Approved may be set when collection is paused

### DIFF
--- a/packages/nft/src/interfaces/types.ts
+++ b/packages/nft/src/interfaces/types.ts
@@ -536,13 +536,6 @@ class CollectionData extends Struct({
   static requireTransferApproval(packed: Field) {
     return packed.toBits(3 + 32 + 64)[1];
   }
-
-  static mintingIsLimited(packed: Field) {
-    const bits = packed.toBits(3 + 32 + 64);
-    const isPaused = bits[0];
-    const mintingIsLimited = bits[2];
-    return isPaused.or(mintingIsLimited);
-  }
 }
 
 /**


### PR DESCRIPTION
The approveAddressByProof() method is used to approve an address to transfer the NFT.  This method is missing a validation to check if CollectionData.isPaused is false, which enables approving addresses even when the collection is paused.

```typescript
    @method async approveAddressByProof(
      nftAddress: PublicKey,
      approved: PublicKey
    ): Promise<void> {
      // Veridise - Missing check which validates that collection is not paused.
			//[...elided]
      this.emitEvent("approve", new ApproveEvent({ nftAddress, approved }));
    }
```

Additionally, there are several other actions within the collection which can be performed while the collection is paused. These include mintByCreator(), mint(), approveAddressByproof(), upgradeNFTVerificationKeyBySignature(), upgradeNFTVerificationKeyByProof(), upgradeVerificationKey(), pauseNFTBySignature(), pauseNFTByProof(), resumeNFT() and resumeNFTByProof(). And NFT.upgradeVerificationKey() can be performed when an NFT is paused.

Out of these, the mintByCreator() is intended to work even with a paused collection to be able to mint the Master NFT which holds the collection metadata. But, there is no documentation which refers to the allowance or disallowance of the other mentioned actions, within a paused collection.

## Recommendation

Add validation to check if the contract is currently paused using `CollectionData.isPaused`.

Also, add documentation which lists the allowed and disallowed actions for a paused collection and/or NFT, and add validations to the aforementioned functions accordingly.