### PR TITLE
fix: Duplicate and unused program constructs

### DIFF
--- a/packages/storage/src/storage/storage.ts
+++ b/packages/storage/src/storage/storage.ts
@@ -60,6 +60,6 @@ export class Storage extends Struct({
   }
 
   isEmpty(): Bool {
-    return this.url[0].equals(Field(0)).and(this.url[1].equals(Field(0)));
+    return Storage.equals(this, Storage.empty());
   }
 }


### PR DESCRIPTION
The following program constructs are unused or duplicate constructs:

 `packages/storage/src/storage/storage.ts`:
    `Storage.isEmpty()`: This function effectively inlines both `Storage.equals()` and `Storage.empty()`.