### PR TITLE
fix: Transfer event emitted twice

### DIFF
--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -755,7 +755,6 @@ function CollectionFactory(params: {
       const adminContract = this.getAdminContract();
       const canTransfer = await adminContract.canTransfer(transferEvent);
       canTransfer.assertTrue();
-      this.emitEvent("transfer", transferEvent);
     }
 
     /**


### PR DESCRIPTION
The approvedTransferBySignature() event emits a transfer event. However, _transfer emits the same event.

```typescript
 @method async approvedTransferBySignature(
      params: TransferParams
    ): Promise<void> {
      // [VERIDISE] elided...
      const transferEvent = await this._transfer({
        transferEventDraft,
        transferFee: collectionData.transferFee,
        royaltyFee: collectionData.royaltyFee,
      });
      // [VERIDISE] elided...
      this.emitEvent("transfer", transferEvent);
    }

```

## Recommendation

Remove the second event emission.