### PR TITLE
fix: Missing checks in Admin.deploy()

### DIFF
--- a/packages/nft/src/contracts/admin.ts
+++ b/packages/nft/src/contracts/admin.ts
@@ -12,6 +12,7 @@ import {
   Field,
   AccountUpdate,
   UInt32,
+  assert,
 } from "o1js";
 import {
   MintRequest,
@@ -79,9 +80,15 @@ class NFTAdmin
    */
   async deploy(props: NFTAdminDeployProps) {
     await super.deploy(props);
+    const isPaused = props.isPaused ?? Bool(false);
+    const canBePaused = props.canBePaused ?? Bool(true);
+    assert(
+      isPaused.equals(Bool(false)).or(canBePaused.equals(Bool(true))),
+      "Cannot deploy paused contract that cannot be resumed"
+    );
     this.admin.set(props.admin);
-    this.isPaused.set(props.isPaused ?? Bool(false));
-    this.canBePaused.set(props.canBePaused ?? Bool(true));
+    this.isPaused.set(isPaused);
+    this.canBePaused.set(canBePaused);
     this.allowChangeRoyalty.set(props.allowChangeRoyalty ?? Bool(false));
     this.allowChangeTransferFee.set(
       props.allowChangeTransferFee ?? Bool(false)


### PR DESCRIPTION
The `Admin.deploy()` function creates the `AccountUpdate` which admins should use to deploy the `Admin` contract. However, there are no internal consistency checks to ensure that if the contract is deployed with `canBePaused = false`, then `isPaused = false`.

If this does happen, then the contract cannot be resumed.

```typescript
  @method
  async resume(): Promise<void> {
    await this.ensureOwnerSignature();
    this.canBePaused.getAndRequireEquals().assertTrue();
    this.isPaused.set(Bool(false));
```

## Recommendation

Validate that `canBePaused` and `isPaused` are not both false before creating the deployment `AccountUpdate`.