### PR TITLE
fix: Admin may deploy unusable NFT vkey

### DIFF
--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -411,23 +411,13 @@ function CollectionFactory(params: {
       const devnetVerificationKeyHash = Field(
         nftVerificationKeys.devnet.vk.NFT.hash
       );
-      const isMainnet = Provable.witness(Bool, () => {
-        // This check does NOT create a constraint on the verification key
-        // as this witness can be replaced during runtime
-        // and is useful only for making sure that the verification key
-        // of the NFT will match the compiled verification key of the NFT
-        // at the time of the deployment of the Collection Contract
-        return Bool(Mina.getNetworkId() === "mainnet");
-      });
       // We check that the verification key hash is the same as the one
-      // that was compiled at the time of the deployment
-      verificationKey.hash.assertEquals(
-        Provable.if(
-          isMainnet,
-          mainnetVerificationKeyHash,
-          devnetVerificationKeyHash
-        )
-      );
+      // that was compiled at the time of the collection deployment
+      if (Mina.getNetworkId() === "mainnet") {
+        verificationKey.hash.assertEquals(mainnetVerificationKeyHash);
+      } else {
+        verificationKey.hash.assertEquals(devnetVerificationKeyHash);
+      }
       update.body.update.verificationKey = {
         isSome: Bool(true),
         value: verificationKey,


### PR DESCRIPTION
The `_mint()` function deploys an `NFT` contract at a new `Account` after `admin` or `creator` approval has been validated. The `verificationKey` is constrained using results from `Provable.witness()` (arbitrary instances of the provable types provided at runtime by whoever generates the proof) and two constants: the verification keys of the `NFT` contract compiled for the mainnet and devnet proving systems.

Since `isMainnet` is an arbitrary `Bool`, a prover may choose to set `verificationKey` to *either* the mainnet or devnet keys.

```typescript
  const verificationKey: VerificationKey = Provable.witness(
    VerificationKey,
    () => // [VERIDISE] arbitrary prover code
  );

  const mainnetVerificationKeyHash = Field(
    nftVerificationKeys.mainnet.vk.NFT.hash
  );
  const devnetVerificationKeyHash = Field(
    nftVerificationKeys.devnet.vk.NFT.hash
  );
  const isMainnet = Provable.witness(Bool, () => // [VERIDISE] arbitrary prover code
  );
  // We check that the verification key hash is the same as the one
  // that was compiled at the time of the deployment
  verificationKey.hash.assertEquals(
    Provable.if(
      isMainnet,
      mainnetVerificationKeyHash,
      devnetVerificationKeyHash
    )
  );
```

## Recommendation

Instead of using `Provable.if()`, use a regular JavaScript `if`/`else` block. Whichever path is taken at circuit-compilation time will be hard-coded into the circuit.

For example, in the below code snippet, `Contract0` and `Contract2` are identical when `config` is `false` at compilation time, while `Contract0` and `Contract1` are identical when `config` is `true` at compilation time.

```typescript
let config: boolean = false;

class Contract0 extends SmartContract {
    @state(Bool) dummy = State<Bool>();
    @method async noop(): Promise<void> {
        if(config) {
            const dummy = this.dummy.getAndRequireEquals();
            dummy.assertTrue();
        }
    }
}

class Contract1 extends SmartContract {
    @state(Bool) dummy = State<Bool>();
    @method async noop(): Promise<void> {
        const dummy = this.dummy.getAndRequireEquals();
        dummy.assertTrue();
    }
}

class Contract2 extends SmartContract {
    @state(Bool) dummy = State<Bool>();
    @method async noop(): Promise<void> {
    }
}
```