### PR TITLE
fix: Unused Imports

### DIFF
--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -21,7 +21,6 @@ import {
   VerificationKey,
   UInt32,
   UInt64,
-  SmartContract,
   Mina,
   Provable,
 } from "o1js";

--- a/packages/nft/src/interfaces/ownable.ts
+++ b/packages/nft/src/interfaces/ownable.ts
@@ -1,4 +1,4 @@
-import { PublicKey, SmartContract, Field, Struct, Bool } from "o1js";
+import { PublicKey, SmartContract, Struct } from "o1js";
 
 /**
  * Interface representing ownable functionality for smart contracts.

--- a/packages/nft/src/interfaces/pausable.ts
+++ b/packages/nft/src/interfaces/pausable.ts
@@ -1,4 +1,4 @@
-import { SmartContract, Field, Struct, Bool } from "o1js";
+import { SmartContract, Struct, Bool } from "o1js";
 export { PausableContract, PauseEvent };
 
 /**


### PR DESCRIPTION
Some imports from `o1js` are never used within context of the files

`contracts/collection.ts`
`interfaces/pausable.ts`