### PR TITLE
fix: from param unused in transfer functions

### DIFF
--- a/packages/abi/src/nft/build.ts
+++ b/packages/abi/src/nft/build.ts
@@ -39,7 +39,7 @@ import {
   MintParams,
   NFTData,
   fieldToString,
-  TransferParams,
+  TransferBySignatureParams,
   UInt64Option,
   NFTTransactionContext,
 } from "@silvana-one/nft";
@@ -828,15 +828,14 @@ export async function buildNftTransaction(params: {
               custom: [Field(0), Field(0), Field(0)],
             });
 
-        const transferParams: TransferParams = {
+        const transferParams: TransferBySignatureParams = {
           address: nftAddress,
-          from,
           to,
           price: price ? UInt64Option.from(price) : UInt64Option.none(),
           context,
         };
         if (args.nftTransferParams.requireApproval === true)
-          await zkCollection.approvedTransferBySignature(transferParams);
+          await zkCollection.adminApprovedTransferBySignature(transferParams);
         else await zkCollection.transferBySignature(transferParams);
         break;
 

--- a/packages/api/open-api.yaml
+++ b/packages/api/open-api.yaml
@@ -2376,7 +2376,6 @@ components:
     NftTransferParams:
       type: object
       required:
-        - from
         - to
       properties:
         from:

--- a/packages/api/src/client/types.gen.ts
+++ b/packages/api/src/client/types.gen.ts
@@ -769,7 +769,7 @@ export type NftTransferParams = {
     /**
      * The address of the owner or approved
      */
-    from: string;
+    from?: string;
     /**
      * The address of the recipient
      */

--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -29,7 +29,8 @@ import { NFT } from "./nft.js";
 import {
   MintParams,
   MintRequest,
-  TransferParams,
+  TransferBySignatureParams,
+  TransferByProofParams,
   CollectionData,
   NFTUpdateProof,
   NFTStateStruct,
@@ -594,7 +595,9 @@ function CollectionFactory(params: {
      * @param to - The recipient's public key.
      * @param price - The price of the NFT (optional).
      */
-    @method async transferBySignature(params: TransferParams): Promise<void> {
+    @method async transferBySignature(
+      params: TransferBySignatureParams
+    ): Promise<void> {
       const { address, to, price, context } = params;
       const collectionData = CollectionData.unpack(
         this.packedData.getAndRequireEquals()
@@ -629,7 +632,9 @@ function CollectionFactory(params: {
      *
      * @param params - The transfer parameters.
      */
-    @method async transferByProof(params: TransferParams): Promise<void> {
+    @method async transferByProof(
+      params: TransferByProofParams
+    ): Promise<void> {
       const { address, from, to, price, context } = params;
       const collectionData = CollectionData.unpack(
         this.packedData.getAndRequireEquals()
@@ -675,8 +680,8 @@ function CollectionFactory(params: {
      *
      * @param params - The transfer parameters.
      */
-    @method async approvedTransferByProof(
-      params: TransferParams
+    @method async adminApprovedTransferByProof(
+      params: TransferByProofParams
     ): Promise<void> {
       const { address, from, to, price, context } = params;
       const collectionData = CollectionData.unpack(
@@ -727,8 +732,8 @@ function CollectionFactory(params: {
      * @param to - The recipient's public key.
      * @param price - The price of the NFT (optional).
      */
-    @method async approvedTransferBySignature(
-      params: TransferParams
+    @method async adminApprovedTransferBySignature(
+      params: TransferBySignatureParams
     ): Promise<void> {
       const { address, to, price, context } = params;
       const collectionData = CollectionData.unpack(

--- a/packages/nft/src/interfaces/collection.ts
+++ b/packages/nft/src/interfaces/collection.ts
@@ -1,5 +1,9 @@
 import { PublicKey, TokenContract } from "o1js";
-import { TransferParams, NFTStateStruct } from "./types.js";
+import {
+  TransferBySignatureParams,
+  TransferByProofParams,
+  NFTStateStruct,
+} from "./types.js";
 import { NFTOwnerContractConstructor } from "./owner.js";
 import { NFTApprovalContractConstructor } from "./approval.js";
 import { NFTUpdateContractConstructor } from "./update.js";
@@ -20,26 +24,28 @@ type NFTCollectionBase = TokenContract & {
    *
    * @param params - The transfer details.
    */
-  transferByProof(params: TransferParams): Promise<void>;
+  transferByProof(params: TransferByProofParams): Promise<void>;
   /**
    * Transfers ownership of an NFT from contract without admin approval.
    *
    * @param params - The transfer details.
    */
-  transferBySignature(params: TransferParams): Promise<void>;
+  transferBySignature(params: TransferBySignatureParams): Promise<void>;
 
   /**
    * Transfers ownership of an NFT from contract without admin approval using a proof.
    *
    * @param params - The transfer details.
    */
-  approvedTransferByProof(params: TransferParams): Promise<void>;
+  adminApprovedTransferByProof(params: TransferByProofParams): Promise<void>;
   /**
    * Transfers ownership of an NFT from contract without admin approval.
    *
    * @param params - The transfer details.
    */
-  approvedTransferBySignature(params: TransferParams): Promise<void>;
+  adminApprovedTransferBySignature(
+    params: TransferBySignatureParams
+  ): Promise<void>;
 
   /**
    * Returns the state of an NFT.

--- a/packages/nft/src/interfaces/types.ts
+++ b/packages/nft/src/interfaces/types.ts
@@ -24,7 +24,8 @@ export {
   NFTUpdateProof,
   NFTStateStruct,
   UInt64Option,
-  TransferParams,
+  TransferBySignatureParams,
+  TransferByProofParams,
   MAX_ROYALTY_FEE,
   NFTTransactionContext,
   TransferExtendedParams,
@@ -587,9 +588,23 @@ class MintRequest extends Struct({
 }) {}
 
 /**
- * Represents the parameters required for transferring an NFT.
+ * Represents the parameters required for transferring an NFT using a signature.
  */
-class TransferParams extends Struct({
+class TransferBySignatureParams extends Struct({
+  /** The address of the NFT contract. */
+  address: PublicKey,
+  /** The receiver's public key. */
+  to: PublicKey,
+  /** Optional price for the transfer. */
+  price: UInt64Option,
+  /** Custom value that can be interpreted by the owner or approved contract. */
+  context: NFTTransactionContext,
+}) {}
+
+/**
+ * Represents the parameters required for transferring an NFT using a proof.
+ */
+class TransferByProofParams extends Struct({
   /** The address of the NFT contract. */
   address: PublicKey,
   /** The sender's public key. */

--- a/packages/nft/src/marketplace/auction.ts
+++ b/packages/nft/src/marketplace/auction.ts
@@ -23,7 +23,8 @@ import {
   NFTCollectionBase,
   NFTTransactionContext,
   TransferExtendedParams,
-  TransferParams,
+  TransferBySignatureParams,
+  TransferByProofParams,
 } from "../interfaces/index.js";
 import { mulDiv } from "../util/index.js";
 
@@ -231,7 +232,7 @@ export function AuctionFactory(params: {
 
     events = {
       bid: AuctionBidEvent,
-      settleAuction: TransferParams,
+      settleAuction: TransferByProofParams,
       canTransfer: TransferEvent,
       settlePayment: UInt64,
       settleAuctioneerPayment: UInt64,
@@ -337,7 +338,7 @@ export function AuctionFactory(params: {
         "Bidder does not have enough balance"
       );
       const collection = this.getCollectionContract(auction.collection);
-      const transferParams = new TransferParams({
+      const transferParams = new TransferByProofParams({
         address: nftAddress,
         from: this.address,
         to: auction.bidder,
@@ -366,7 +367,7 @@ export function AuctionFactory(params: {
       const nftAddress = auction.nft;
 
       const collection = this.getCollectionContract(auction.collection);
-      const transferParams = new TransferParams({
+      const transferParams = new TransferByProofParams({
         address: nftAddress,
         from: this.address,
         to: auction.owner,

--- a/packages/nft/src/marketplace/bid.ts
+++ b/packages/nft/src/marketplace/bid.ts
@@ -25,7 +25,7 @@ import {
 import {
   NFTCollectionBase,
   NFTCollectionContractConstructor,
-  TransferParams,
+  TransferBySignatureParams,
   UInt64Option,
   NFTTransactionContext,
 } from "../interfaces/index.js";
@@ -178,9 +178,8 @@ export function BidFactory(params: {
       const Collection = collectionContract();
       const collection = new Collection(nftAddress.collection);
       await collection.transferBySignature(
-        new TransferParams({
+        new TransferBySignatureParams({
           address: nftAddress.nft,
-          from: PublicKey.empty(),
           to: buyer,
           price: UInt64Option.fromValue(price),
           context: new NFTTransactionContext({
@@ -195,10 +194,9 @@ export function BidFactory(params: {
       const buyer = this.buyer.getAndRequireEquals();
       const Collection = collectionContract();
       const collection = new Collection(nftAddress.collection);
-      await collection.approvedTransferBySignature(
-        new TransferParams({
+      await collection.adminApprovedTransferBySignature(
+        new TransferBySignatureParams({
           address: nftAddress.nft,
-          from: PublicKey.empty(),
           to: buyer,
           price: UInt64Option.fromValue(price),
           context: new NFTTransactionContext({

--- a/packages/nft/test/auction.test.ts
+++ b/packages/nft/test/auction.test.ts
@@ -34,22 +34,18 @@ import {
   NFTData,
   MintParams,
   nftVerificationKeys,
-  BidFactory,
   UInt64Option,
   AuctionFactory,
   Auction,
   AdminData,
   NFTCollectionContractConstructor,
-  TransferParams,
+  TransferByProofParams,
+  TransferBySignatureParams,
   NFTTransactionContext,
   NFTSharesFactory,
   NFTOwnerContractConstructor,
   NFTAdminContractConstructor,
   NFTApprovalContractConstructor,
-  NFTStandardOwner,
-  DefineApprovalFactory,
-  DefineOwnerFactory,
-  OfferFactory,
   CollectionFactory,
   NFTStandardUpdate,
   NFTUpdateContractConstructor,
@@ -824,10 +820,9 @@ describe(`Auction contracts tests: ${chain} ${withdraw ? "withdraw " : ""}${
       },
       async () => {
         if (requireTransferApproval) {
-          await collectionContract.approvedTransferBySignature(
-            new TransferParams({
+          await collectionContract.adminApprovedTransferBySignature(
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -835,9 +830,8 @@ describe(`Auction contracts tests: ${chain} ${withdraw ? "withdraw " : ""}${
           );
         } else {
           await collectionContract.transferBySignature(
-            new TransferParams({
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -899,10 +893,9 @@ describe(`Auction contracts tests: ${chain} ${withdraw ? "withdraw " : ""}${
       async () => {
         AccountUpdate.fundNewAccount(seller, 1);
         if (withdraw) {
-          await collectionContract.approvedTransferBySignature(
-            new TransferParams({
+          await collectionContract.adminApprovedTransferBySignature(
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: seller,
               to: zkAuctionKey,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -1629,10 +1622,9 @@ describe(`Auction contracts tests: ${chain} ${withdraw ? "withdraw " : ""}${
       },
       async () => {
         if (requireTransferApproval) {
-          await collectionContract.approvedTransferBySignature(
-            new TransferParams({
+          await collectionContract.adminApprovedTransferBySignature(
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -1640,9 +1632,8 @@ describe(`Auction contracts tests: ${chain} ${withdraw ? "withdraw " : ""}${
           );
         } else {
           await collectionContract.transferBySignature(
-            new TransferParams({
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -1703,8 +1694,8 @@ describe(`Auction contracts tests: ${chain} ${withdraw ? "withdraw " : ""}${
         },
         async () => {
           if (requireTransferApproval) {
-            await sharesCollectionContract.approvedTransferByProof(
-              new TransferParams({
+            await sharesCollectionContract.adminApprovedTransferByProof(
+              new TransferByProofParams({
                 address: zkNFTKey,
                 from: zkSharesKey,
                 to,
@@ -1714,7 +1705,7 @@ describe(`Auction contracts tests: ${chain} ${withdraw ? "withdraw " : ""}${
             );
           } else {
             await sharesCollectionContract.transferByProof(
-              new TransferParams({
+              new TransferByProofParams({
                 address: zkNFTKey,
                 from: zkSharesKey,
                 to,

--- a/packages/nft/test/contract.test.ts
+++ b/packages/nft/test/contract.test.ts
@@ -50,7 +50,7 @@ import {
   DefineApprovalFactory,
   NFTCollectionContractConstructor,
   NFTAdminContractConstructor,
-  TransferParams,
+  TransferBySignatureParams,
   NFTTransactionContext,
 } from "../src/index.js";
 import {
@@ -1139,10 +1139,9 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
       },
       async () => {
         if (requireTransferApproval) {
-          await collectionContract.approvedTransferBySignature(
-            new TransferParams({
+          await collectionContract.adminApprovedTransferBySignature(
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -1150,9 +1149,8 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
           );
         } else {
           await collectionContract.transferBySignature(
-            new TransferParams({
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -1246,10 +1244,9 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
         },
         async () => {
           if (requireTransferApproval) {
-            await collectionContract.approvedTransferBySignature(
-              new TransferParams({
+            await collectionContract.adminApprovedTransferBySignature(
+              new TransferBySignatureParams({
                 address: zkNFTKey,
-                from: owner,
                 to,
                 price: UInt64Option.none(),
                 context: NFTTransactionContext.empty(),
@@ -1257,9 +1254,8 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
             );
           } else {
             await collectionContract.transferBySignature(
-              new TransferParams({
+              new TransferBySignatureParams({
                 address: zkNFTKey,
-                from: owner,
                 to,
                 price: UInt64Option.none(),
                 context: NFTTransactionContext.empty(),
@@ -1354,10 +1350,9 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
       },
       async () => {
         if (requireTransferApproval) {
-          await collectionContract.approvedTransferBySignature(
-            new TransferParams({
+          await collectionContract.adminApprovedTransferBySignature(
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -1365,9 +1360,8 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
           );
         } else {
           await collectionContract.transferBySignature(
-            new TransferParams({
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -1451,10 +1445,9 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
         },
         async () => {
           if (requireTransferApproval) {
-            await collectionContract.approvedTransferBySignature(
-              new TransferParams({
+            await collectionContract.adminApprovedTransferBySignature(
+              new TransferBySignatureParams({
                 address: zkNFTKey,
-                from: owner,
                 to,
                 price: UInt64Option.none(),
                 context: NFTTransactionContext.empty(),
@@ -1462,9 +1455,8 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
             );
           } else {
             await collectionContract.transferBySignature(
-              new TransferParams({
+              new TransferBySignatureParams({
                 address: zkNFTKey,
-                from: owner,
                 to,
                 price: UInt64Option.none(),
                 context: NFTTransactionContext.empty(),
@@ -1846,10 +1838,9 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
       },
       async () => {
         if (requireTransferApproval) {
-          await collectionContract.approvedTransferBySignature(
-            new TransferParams({
+          await collectionContract.adminApprovedTransferBySignature(
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),
@@ -1857,9 +1848,8 @@ describe(`NFT contracts tests: ${chain} ${useAdvancedAdmin ? "advanced " : ""}${
           );
         } else {
           await collectionContract.transferBySignature(
-            new TransferParams({
+            new TransferBySignatureParams({
               address: zkNFTKey,
-              from: owner,
               to,
               price: UInt64Option.none(),
               context: NFTTransactionContext.empty(),

--- a/packages/nft/test/zkprogram.test.ts
+++ b/packages/nft/test/zkprogram.test.ts
@@ -42,7 +42,7 @@ import {
   Metadata,
   NonFungibleTokenContractsFactory,
   NFTTransactionContext,
-  TransferParams,
+  TransferBySignatureParams,
   NFTUpdateBase,
   MetadataValue,
 } from "../src/index.js";
@@ -943,10 +943,9 @@ describe(`NFT ZkProgram tests: ${chain} ${readOnly ? "read-only " : ""}${
         },
         async () => {
           if (requireTransferApproval) {
-            await collectionContract.approvedTransferBySignature(
-              new TransferParams({
+            await collectionContract.adminApprovedTransferBySignature(
+              new TransferBySignatureParams({
                 address: zkNFTKey,
-                from: owner,
                 to,
                 price: UInt64Option.none(),
                 context: NFTTransactionContext.empty(),
@@ -954,9 +953,8 @@ describe(`NFT ZkProgram tests: ${chain} ${readOnly ? "read-only " : ""}${
             );
           } else {
             await collectionContract.transferBySignature(
-              new TransferParams({
+              new TransferBySignatureParams({
                 address: zkNFTKey,
-                from: owner,
                 to,
                 price: UInt64Option.none(),
                 context: NFTTransactionContext.empty(),


### PR DESCRIPTION
The function `transferBySignature()` can be used to transfer an NFT without admin approval. Correspondingly, its counterpart `approvedTransferBySignature()` requires approval from the admin to transfer an NFT. If the NFT owner is a contract then `transferByProof()` and `approvedTransferByProof()` can be used respectively. 

The signature-based transfers rely on creating an `AccountUpdate` from the (unconstrained) `sender`, and then checking that the `sender` is either the `owner` or the `approved` contract. Consequently, as shown in the below snippet, the “`params.from`" address is ignored.

```typescript
    @method async approvedTransferBySignature(
      params: TransferParams
    ): Promise<void> {
      const { address, to, price, context } = params;
			//[Veridise] 
			//...elided....
			//[Veridise]
       const transferEventDraft = new TransferExtendedParams({
        from: PublicKey.empty(), // will be added later
        //[Veridise] 
			  //...elided....
      });
      await this._transfer({
        transferEventDraft,
        //[Veridise] 
			  //...elided....
      });
    }
```

## Recommendation

Consider removing the `from` parameter from the signature-based transfer arguments.

Consider renaming the `approved*` transfer methods to `adminApproved*`.