### PR TITLE
fix: Maliciously upgraded NFTs may mint new NFTs

### DIFF
--- a/packages/nft/src/contracts/collection.ts
+++ b/packages/nft/src/contracts/collection.ts
@@ -446,6 +446,7 @@ function CollectionFactory(params: {
           access: Permissions.proof(),
           setZkappUri: Permissions.impossible(),
           setTokenSymbol: Permissions.impossible(),
+          receive: Permissions.impossible(),
         },
       };
       const initialState = new NFTStateStruct({
@@ -876,6 +877,23 @@ function CollectionFactory(params: {
       address: PublicKey,
       vk: VerificationKey
     ): Promise<UpgradeVerificationKeyData> {
+      const mainnetVerificationKeyHash = Field(
+        nftVerificationKeys.mainnet.vk.NFT.hash
+      );
+      const devnetVerificationKeyHash = Field(
+        nftVerificationKeys.devnet.vk.NFT.hash
+      );
+      // We check that the verification key hash is the same as the one
+      // that was compiled at the time of the collection deployment or upgrade,
+      // as the case can be.
+      // The upgrade procedure:
+      // 1. upgradeVerificationKey() is called on old collection contract to upgrade the verification key of the collection
+      // 2. upgradeNFTVerificationKey() is called on new collection contract to upgrade the verification key of the NFT
+      if (Mina.getNetworkId() === "mainnet") {
+        vk.hash.assertEquals(mainnetVerificationKeyHash); // this constant should be changed at the time of the collection upgrade
+      } else {
+        vk.hash.assertEquals(devnetVerificationKeyHash); // this constant should be changed at the time of the collection upgrade
+      }
       const tokenId = this.deriveTokenId();
       const nft = new NFT(address, tokenId);
       const adminContract = this.getAdminContract();


### PR DESCRIPTION
Since an AccountUpdate's children may inherit its token ID, a malicious NFT implementation could approve arbitrary AccountUpdates to create new Accounts with the Collection's tokenId. This is impossible with the default NFT verification key. However, if a malicious NFT upgrade occurs, an attacker could use this ability to mint arbitrary NFTs to the Collection.

## Recommendation

Ideally, the `Collection` would validate that `NFT` updates have no children of their own, as in the expected implementation of the `NFT`. Doing this is not easy with the current o1js APIs. It would require iterating over the o1js `AccountUpdateLayout` to find the child update representing an `NFTAccountUpdate` as an entry in the `MerkleList` of children, and then validating that it itself has no children.

Instead, consider validating the `NFT` verification key hash matches the expected one on each `@method` call.

Additionally, consider setting the `NFT` receive permissions to `Permissions.impossible()` to ensure rogue NFT implementations cannot increase the balance on their account.